### PR TITLE
nestjs jest 설정 변경 및 테스트 실패 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,20 +60,26 @@
     "typescript": "^5.1.3"
   },
   "jest": {
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ],
     "moduleFileExtensions": [
       "js",
       "json",
       "ts"
     ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
+    "roots": [
+      "src"
+    ],
+    "testRegex": ".spec.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "src/(.*)": "<rootDir>/src/$1"
+    }
   }
 }

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -2,6 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtService } from '@nestjs/jwt';
+import { UsersService } from 'src/users/users.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserTable } from 'src/users/entities/user.entity';
+import { UsersMockRepository } from 'src/users/mocks/repository.mock';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -9,7 +13,15 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [AuthService, JwtService],
+      providers: [
+        AuthService,
+        JwtService,
+        UsersService,
+        {
+          provide: getRepositoryToken(UserTable),
+          useClass: UsersMockRepository,
+        },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,13 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
 import { JwtService } from '@nestjs/jwt';
+import { UsersService } from 'src/users/users.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserTable } from 'src/users/entities/user.entity';
+import { UsersMockRepository } from 'src/users/mocks/repository.mock';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService, JwtService],
+      providers: [
+        AuthService,
+        JwtService,
+        UsersService,
+        {
+          provide: getRepositoryToken(UserTable),
+          useClass: UsersMockRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);

--- a/src/scores/scores.controller.spec.ts
+++ b/src/scores/scores.controller.spec.ts
@@ -1,6 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ScoresController } from './scores.controller';
 import { ScoresService } from './scores.service';
+import { AuthService } from 'src/auth/auth.service';
+import { UsersService } from 'src/users/users.service';
+import { JwtService } from '@nestjs/jwt';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserTable } from 'src/users/entities/user.entity';
+import { UsersMockRepository } from 'src/users/mocks/repository.mock';
 
 describe('ScoresController', () => {
   let controller: ScoresController;
@@ -8,7 +14,16 @@ describe('ScoresController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ScoresController],
-      providers: [ScoresService],
+      providers: [
+        ScoresService,
+        AuthService,
+        UsersService,
+        JwtService,
+        {
+          provide: getRepositoryToken(UserTable),
+          useClass: UsersMockRepository,
+        },
+      ],
     }).compile();
 
     controller = module.get<ScoresController>(ScoresController);


### PR DESCRIPTION
nestjs 기본 jest 설정에 문제가 있다고 합니다.
상대 경로로 설정되어 있는 것들을 잘 잡지 못하여 생기는 버그 같습니다 관련된 링크를 첨부합니다.
https://stackoverflow.com/questions/50171412/absolute-paths-baseurl-gives-error-cannot-find-module/51174924#51174924

수정하고 테스팅 실패를 해결했습니다.