### PR TITLE
[BE] fix: 방 입/퇴장시 정보 갱신 문제 수정

### DIFF
--- a/src/rooms/rooms.gateway.ts
+++ b/src/rooms/rooms.gateway.ts
@@ -160,6 +160,7 @@ export class RoomsGateway {
       status: 'success',
       message: '방에 입장했습니다.',
       userList: this.roomsService.getAllClient(roomId),
+      ...roomInfo,
     });
   }
 

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -63,6 +63,10 @@ export class RoomsService {
     client.leave(roomId);
     client.data.user.ready = false;
     this.deleteUserFromList(client, roomId);
+    
+    if (this.roomList[roomId].userList.length === 0) {
+      delete this.roomList[roomId];
+    }
   }
 
   getGameRoom(roomId: string): RoomInfo {


### PR DESCRIPTION
### 인원이 0명인 방이 로비 리스트에 계속 남아있는 문제 발생
서버에서 방을 담은 리스트에 인원이 0명인 방이 계속 남아있었다. 방을 나갈 때 인원이 0명인지 확인해서 리스트에서 지워주도록 수정했다.

### 유저가 방에 입장시 방 정보를 전달하지 않는 문제 발생
유저가 방에 입장할 때 roomInfo를 추가로 전달하도록 수정했다.