### PR TITLE
엔드포인트 경로 api/...로 변경

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,7 +6,7 @@ import { User } from 'src/users/decorators/user.decorator';
 import { RefreshTokenGuard } from './guard/bearer-token.guard';
 import { Token } from './decorators/token.decorator';
 
-@Controller('auth')
+@Controller('api/auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 

--- a/src/problems/problems.controller.ts
+++ b/src/problems/problems.controller.ts
@@ -16,7 +16,7 @@ import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 import { CreateProblemDto } from './dto/create-problem.dto';
 import { AdminGuard } from 'src/auth/guard/admin.guard';
 
-@Controller('problems')
+@Controller('api/problems')
 export class ProblemsController {
   constructor(private readonly problemsService: ProblemsService) {}
 

--- a/src/scores/scores.controller.ts
+++ b/src/scores/scores.controller.ts
@@ -8,7 +8,7 @@ import { ScoreSubmissionDto } from './dto/score-submission.dto';
 export class ScoresController {
   constructor(private readonly scoresService: ScoresService) {}
 
-  @Post('/grade')
+  @Post('api/grade')
   @UseGuards(AccessTokenGuard)
   async grade(@Body() submission: ScoreSubmissionDto, @User() user) {
     return await this.scoresService.grade(submission, user);

--- a/src/submissions/submissions.controller.ts
+++ b/src/submissions/submissions.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { SubmissionsService } from './submissions.service';
 
-@Controller('submissions')
+@Controller('api/submissions')
 export class SubmissionsController {
   constructor(private readonly submissionsService: SubmissionsService) {}
   @Get()

--- a/src/testcases/testcases.controller.ts
+++ b/src/testcases/testcases.controller.ts
@@ -17,7 +17,7 @@ import { AdminGuard } from 'src/auth/guard/admin.guard';
 import { CreateTestcaseDto } from './dto/create-testcase.dto';
 import { UpdateTestcaseDto } from './dto/update-testcase.dto';
 
-@Controller('testcases')
+@Controller('api/testcases')
 export class TestcasesController {
   constructor(private readonly testcasesService: TestcasesService) {}
   @Get()

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
 import { UsersService } from './users.service';
 
-@Controller('users')
+@Controller('api/users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 


### PR DESCRIPTION
엔진엑스에서 static 파일 서빙과 api 엔드포인트 경로를 구분하기 위해, api 서버의 엔드포인트에 api/를 붙혔습니다.