### PR TITLE
라우팅 url 수정되지 않은 부분 수정 및 에러 헨들링 부분 추가

### DIFF
--- a/src/problems/dto/create-problem.dto.ts
+++ b/src/problems/dto/create-problem.dto.ts
@@ -6,4 +6,5 @@ export class CreateProblemDto extends PickType(ProblemTable, [
   'description',
   'timeLimit',
   'memoryLimit',
+  'sampleCode',
 ]) {}

--- a/src/scores/scores.controller.ts
+++ b/src/scores/scores.controller.ts
@@ -4,11 +4,11 @@ import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 import { User } from 'src/users/decorators/user.decorator';
 import { ScoreSubmissionDto } from './dto/score-submission.dto';
 
-@Controller('v2/scores')
+@Controller('api/scores')
 export class ScoresController {
   constructor(private readonly scoresService: ScoresService) {}
 
-  @Post('api/grade')
+  @Post('grade')
   @UseGuards(AccessTokenGuard)
   async grade(@Body() submission: ScoreSubmissionDto, @User() user) {
     return await this.scoresService.grade(submission, user);

--- a/src/scores/scores.service.ts
+++ b/src/scores/scores.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ScoreSubmissionDto } from './dto/score-submission.dto';
 import { UserTable } from 'src/users/entities/user.entity';
 import { ProblemsService } from 'src/problems/problems.service';
@@ -22,6 +22,11 @@ export class ScoresService {
   async grade(submission: ScoreSubmissionDto, user: UserTable) {
     const { code, problemId, language } = submission;
     const problem = await this.problemsService.getProblem(problemId);
+
+    if (!problem) {
+      throw new BadRequestException('Problem does not exist');
+    }
+
     const promises = [];
 
     for (let i = 0; i < problem.testcases.length; i++) {


### PR DESCRIPTION
1. api/scores/grade로 채점 요청 가능

2. 문제 검색 시, 문제 아이디가 없으면 에러 던짐.

3. create-problem dto에 samplecde 추가