### PR TITLE
[BE] fix: 방을 나가기 전의 userCount를 받아오는 문제

### DIFF
--- a/src/rooms/rooms.gateway.ts
+++ b/src/rooms/rooms.gateway.ts
@@ -169,9 +169,10 @@ export class RoomsGateway {
   @SubscribeMessage('exit_room')
   exitRoom(@ConnectedSocket() client: Socket, @MessageBody() data) {
     const { roomId } = data;
-    const userCount = this.roomsService.getGameRoom(roomId).userCount;
 
     this.roomsService.exitRoom(client, roomId);
+
+    const userCount = this.roomsService.getGameRoom(roomId).userCount;
 
     if (userCount !== 0) {
       this.server.in(roomId).emit('user_exit_room', {


### PR DESCRIPTION
유저가 나간 후의 userCount는 하나가 줄어드는데 그것이 반영되지 않았다.
유저가 1명 있다가 나갔을 때 userCount가 0이 돼야 하는데 1이 돼서 조건문이 실행되는 문제가 발생하므로 수정했다.