### PR TITLE
[BE] fix: 방 퇴장 시 빈 방의 프로퍼티를 조회하는 문제 수정

### DIFF
--- a/api-server/src/rooms/rooms.gateway.ts
+++ b/api-server/src/rooms/rooms.gateway.ts
@@ -174,7 +174,7 @@ export class RoomsGateway {
     
     const userCount = this.roomsService.getGameRoom(roomId).userCount;
 
-    if (userCount !== 0) {
+    if (userCount) {
       this.server.in(roomId).emit('user_exit_room', {
         userName: client.data.user.name,
         message: `${client.data.user.name} 님이 ${

--- a/api-server/src/rooms/rooms.service.ts
+++ b/api-server/src/rooms/rooms.service.ts
@@ -70,6 +70,10 @@ export class RoomsService {
   }
 
   getGameRoom(roomId: string): RoomInfo {
+    if (!this.roomList[roomId]) {
+      return undefined;
+    }
+    
     const room = this.roomList[roomId];
 
     return {


### PR DESCRIPTION
방에 혼자 있을 때 나가면 roomList에서 삭제된다. 그 후 getGameRoom 메서드에서 roomId로 조회하는데 undefined이므로 리턴값에서 undefined의 속성값을 조회하는 오류가 발생한다.