### PR TITLE
[BE] fix: 방이 없어지는 경우 로비에 있는 유저들에게 없어진 방 정보 전송하지 않는 문제

### DIFF
--- a/api-server/src/rooms/rooms.gateway.ts
+++ b/api-server/src/rooms/rooms.gateway.ts
@@ -85,6 +85,9 @@ export class RoomsGateway {
   }
 
   async handleDisconnect(socket: Socket) {
+    this.roomsService.exitRoom(socket, socket.data.roomId);
+    this.roomsService.deleteUserSocket(socket.data.user.name);
+
     if (socket.data.roomId) {
       if (socket.data.roomId === 'lobby') {
         this.server.in(socket.data.roomId).emit('user_exit_lobby', {
@@ -92,14 +95,17 @@ export class RoomsGateway {
           message: `${socket.data.user.name} ${socket.data.roomId} 방에서 나갔습니다.`,
         });
       } else {
-        this.server.in(socket.data.roomId).emit('user_exit_room', {
-          userName: socket.data.user.name,
-          message: `${socket.data.user.name} ${socket.data.roomId} 방에서 나갔습니다.`,
-        });
+        if (this.roomsService.getGameRoom(socket.data.roomId)) {
+          this.server.in(socket.data.roomId).emit('user_exit_room', {
+            userName: socket.data.user.name,
+            message: `${socket.data.user.name} ${socket.data.roomId} 방에서 나갔습니다.`,
+          });
+        } else {
+          this.server.in('lobby').emit('delete_room', {
+            roomId: socket.data.roomId,
+          });
+        }
       }
-
-      this.roomsService.exitRoom(socket, socket.data.roomId);
-      this.roomsService.deleteUserSocket(socket.data.user.name);
     }
   }
 
@@ -171,15 +177,16 @@ export class RoomsGateway {
     const { roomId } = data;
 
     this.roomsService.exitRoom(client, roomId);
-
-    const { userCount } = this.roomsService.getGameRoom(roomId);
-
-    if (userCount) {
+    if (this.roomsService.getGameRoom(roomId)) {
       this.server.in(roomId).emit('user_exit_room', {
         userName: client.data.user.name,
         message: `${client.data.user.name} 님이 ${
           this.roomsService.getGameRoom(roomId).roomName
         } 방에서 나갔습니다.`,
+      });
+    } else {
+      this.server.in('lobby').emit('delete_room', {
+        roomId,
       });
     }
 

--- a/api-server/src/rooms/rooms.service.ts
+++ b/api-server/src/rooms/rooms.service.ts
@@ -71,7 +71,7 @@ export class RoomsService {
 
   getGameRoom(roomId: string): RoomInfo {
     if (!this.roomList[roomId]) {
-      return { userCount: 0 } as RoomInfo;
+      return undefined;
     }
 
     const room = this.roomList[roomId];


### PR DESCRIPTION
방이 없어졌을 때 없어진 방에 대한 정보를 로비의 유저들이 받을 수 있게 했다.
나가기 버튼 뿐만 아니라 브라우저를 꺼서 종료했을 때도 handleDisconnect에서 로비에 있는 유저들에게 정보를 전송하도록 했다.