### PR TITLE
[BE] Fix: socket.data가 undefined 경우 예외처리

### DIFF
--- a/api-server/src/rooms/rooms.gateway.ts
+++ b/api-server/src/rooms/rooms.gateway.ts
@@ -85,9 +85,12 @@ export class RoomsGateway {
   }
 
   async handleDisconnect(socket: Socket) {
+    if (!socket.data.user) {
+      return;
+    }
+
     this.roomsService.exitRoom(socket, socket.data.roomId);
     this.roomsService.deleteUserSocket(socket.data.user.name);
-
     if (socket.data.roomId) {
       if (socket.data.roomId === 'lobby') {
         this.server.in(socket.data.roomId).emit('user_exit_lobby', {

--- a/api-server/src/rooms/rooms.service.ts
+++ b/api-server/src/rooms/rooms.service.ts
@@ -60,7 +60,7 @@ export class RoomsService {
   }
 
   exitRoom(client: Socket, roomId: string) {
-    if (client.rooms) {
+    if (client.rooms.size) {
       client.leave(roomId);
       client.data.user.ready = false;
     }

--- a/api-server/src/rooms/rooms.service.ts
+++ b/api-server/src/rooms/rooms.service.ts
@@ -60,8 +60,10 @@ export class RoomsService {
   }
 
   exitRoom(client: Socket, roomId: string) {
-    client.leave(roomId);
-    client.data.user.ready = false;
+    if (client.rooms) {
+      client.leave(roomId);
+      client.data.user.ready = false;
+    }
     this.deleteUserFromList(client, roomId);
 
     if (roomId !== 'lobby' && this.roomList[roomId].userList.length === 0) {


### PR DESCRIPTION
handleDisconnection에서 exitRoom을 실행할 때 socket.rooms와 socket.data가 초기화되므로 예외 처리를 했다.