### PR TITLE
[BE] Fix: 로거를 NestFactory.create에서 설정

### DIFF
--- a/api-server/src/main.ts
+++ b/api-server/src/main.ts
@@ -5,14 +5,15 @@ import * as cookesParser from 'cookie-parser';
 import { logger } from './utils/logger/winston.config';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    logger,
+  });
   app.useWebSocketAdapter(new SocketIoAdapter(app));
   app.enableCors({
     origin: true,
     credentials: true,
   });
   app.use(cookesParser());
-  app.useLogger(logger);
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
기존 방법으로는 Nest가 처음 앱을 실행할 때에 대한 로그가 기록되지 않아서 방법을 변경했다.