### PR TITLE
[BE] Refactor: 랜덤으로 문제 가져오는 로직 수정

### DIFF
--- a/api-server/src/rooms/rooms.gateway.ts
+++ b/api-server/src/rooms/rooms.gateway.ts
@@ -255,7 +255,7 @@ export class RoomsGateway {
     });
 
     if (this.roomsService.checkUsersReady(roomId)) {
-      const problems = this.problemsService.getProblemsAtRandom(1);
+      const problems = this.problemsService.findProblemsWithTestcases(1);
 
       this.server.in(roomId).emit('start', {
         status: 'start',


### PR DESCRIPTION
전부 가져온 다음 어플리케이션 레벨에서 랜덤으로 뽑는 것보다는 쿼리에서 랜덤으로 뽑아오는 게 낫다는 판단을 했다. 쿼리빌더를 사용해 order by RAND()를 통해 가져오도록 수정했다.