### PR TITLE
[BE] Fix: 문제의 테스트케이스를 하나만 가져오는 문제

### DIFF
--- a/api-server/src/problems/problems.service.ts
+++ b/api-server/src/problems/problems.service.ts
@@ -58,11 +58,20 @@ export class ProblemsService {
         'problem.memoryLimit',
         'problem.timeLimit',
         'problem.sampleCode',
-        'testcase.input',
-        'testcase.output',
+        'testcase',
       ])
       .getMany();
 
-    return problems;
+    return problems.map((problem) => {
+      return {
+        ...problem,
+        testcases: problem.testcases.map((testcase) => {
+          return {
+            input: testcase.input,
+            output: testcase.output,
+          };
+        }),
+      };
+    });
   }
 }


### PR DESCRIPTION
쿼리에서 testcase.input, testcase.output을 select하니까 케이스를 하나만 가져오는 문제가 발생했다. 쿼리상에서 일대다 관계의 테이블을 조인했을 때 특정 칼럼만 가져오는 방법을 알아내지 못해서 map 함수를 이용해 필터링하도록 수정했다.