### PR TITLE
[BE] Feat: 예외 필터 전역화, 로비 입장 소켓 연결과 분리, 방 입장과 정보 받아오는 로직 분리, 이벤트 응답을 return으로 전달

### DIFF
--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -17,7 +17,7 @@
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/platform-socket.io": "^10.2.9",
         "@nestjs/typeorm": "^10.0.0",
-        "@nestjs/websockets": "^10.2.9",
+        "@nestjs/websockets": "^10.2.10",
         "@types/crypto-js": "^4.2.1",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
@@ -1921,9 +1921,9 @@
       }
     },
     "node_modules/@nestjs/websockets": {
-      "version": "10.2.9",
-      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.2.9.tgz",
-      "integrity": "sha512-Hp/ioNMcBtCzkubgcDHeA5KH4YLBL1jHfMEacLctKDa20Kn/LFXhJhXVWEr4jEzUKXbD+Q+GyYk1V/1rJi6eHA==",
+      "version": "10.2.10",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.2.10.tgz",
+      "integrity": "sha512-L1AkxwLUj/ntk26jO1SXYl3GRElQE6Fikzfy/3MPFURk0GDs7tHUzLcb8BC8q8u5ZpUjBAC2wFVQzrY5R0MHNw==",
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -28,7 +28,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/platform-socket.io": "^10.2.9",
     "@nestjs/typeorm": "^10.0.0",
-    "@nestjs/websockets": "^10.2.9",
+    "@nestjs/websockets": "^10.2.10",
     "@types/crypto-js": "^4.2.1",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",

--- a/api-server/src/rooms/entities/room.entity.ts
+++ b/api-server/src/rooms/entities/room.entity.ts
@@ -33,5 +33,5 @@ export interface CreateRoomInfo {
 export interface User {
   userName: string;
   ready: boolean;
-  itemList: Record<string, number>;
+  itemList?: Record<string, number>;
 }

--- a/api-server/src/rooms/entities/room.entity.ts
+++ b/api-server/src/rooms/entities/room.entity.ts
@@ -7,6 +7,7 @@ export interface Room {
   capacity: number;
   state: 'waiting' | 'playing';
   timer: NodeJS.Timeout | null;
+  itmeCreater: NodeJS.Timeout | null;
 }
 
 export interface RoomList {
@@ -32,4 +33,5 @@ export interface CreateRoomInfo {
 export interface User {
   userName: string;
   ready: boolean;
+  itemList: Record<string, number>;
 }

--- a/api-server/src/rooms/rooms.constants.ts
+++ b/api-server/src/rooms/rooms.constants.ts
@@ -1,1 +1,3 @@
 export const TIME_LIMIT = 30000;
+export const NUM_OF_ROUNDS = 1;
+export const LOBBY_ID = 'lobby';


### PR DESCRIPTION
예외 필터를 전역화해서 Gateway 클래스 위에 한 번만 써주도록 변경했다.
`handleConnection`에서 로비 입장까지 같이 해줬던 것을 분리해줬다.
방에 입장할 때 정보도 같이 받아오도록 했는데 정보를 받아오는 로직을 분리했다.
이벤트 응답을 emit으로 전달했는데 return으로 전달하도록 변경했다.