### PR TITLE
[BE] Refactor: 방의 userList에 소켓이 아닌 커스텀 객체를 담도록 수정

### DIFF
--- a/api-server/src/rooms/dtos/rooms.user.dto.ts
+++ b/api-server/src/rooms/dtos/rooms.user.dto.ts
@@ -1,0 +1,40 @@
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsNotEmptyObject,
+  IsObject,
+  IsString,
+} from 'class-validator';
+
+export enum ItemList {
+  SWAP,
+  SCREENBLOCK,
+  TYPERANDOM,
+  TINYCODE,
+  CRAZYMUSIC,
+  REVERSELANGUAGE,
+  STOLEEYE,
+  UNDO,
+  DELAYINPUT,
+}
+
+export class RoomsUserDto {
+  @IsString()
+  @IsNotEmpty()
+  socketId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  userName: string;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  ready: boolean;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  passed: boolean;
+
+  @IsObject()
+  itemList: Record<string, ItemList>;
+}

--- a/api-server/src/rooms/entities/room.entity.ts
+++ b/api-server/src/rooms/entities/room.entity.ts
@@ -1,13 +1,14 @@
 import { Socket } from 'socket.io';
+import { RoomsUser } from './rooms.user.entity';
 
 export interface Room {
   roomId: string;
   roomName: string;
-  userList: Socket[];
+  userList: RoomsUser[];
   capacity: number;
   state: 'waiting' | 'playing';
   timer: NodeJS.Timeout | null;
-  itmeCreater: NodeJS.Timeout | null;
+  itemCreater: NodeJS.Timeout | null;
 }
 
 export interface RoomList {

--- a/api-server/src/rooms/entities/rooms.user.entity.ts
+++ b/api-server/src/rooms/entities/rooms.user.entity.ts
@@ -1,0 +1,29 @@
+import {
+  IsBoolean,
+  IsString,
+  IsObject,
+  IsNotEmpty,
+  IsNotEmptyObject,
+} from 'class-validator';
+import { ItemList } from '../dtos/rooms.user.dto';
+
+export class RoomsUser {
+  @IsString()
+  @IsNotEmpty()
+  socketId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  userName: string;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  ready: boolean;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  passed: boolean;
+
+  @IsObject()
+  itemList: Record<string, ItemList>;
+}


### PR DESCRIPTION
service 계층에서 소켓을 직접적으로 다루는 것은 적절하지 않다고 판단했다. 게이트웨이 단으로 책임을 옮기기 위해 연관된 모든 메서드들을 수정했다. RoomsUserDto와 엔티티를 정의해서 다룰 수 있도록 했고, socketId만 따로 담아서 socket.io의 자체적인 매핑 기능을 통해 필요할 때 게이트웨이 단에서 소켓을 찾을 수 있도록 수정했다.