### PR TITLE
[BE] Feat: 방 입퇴장시 유저카운트 갱신, 기본 방 제목 추가

### DIFF
--- a/api-server/src/rooms/rooms.constants.ts
+++ b/api-server/src/rooms/rooms.constants.ts
@@ -2,3 +2,4 @@ export const TIME_LIMIT = 30000;
 export const NUM_OF_ROUNDS = 1;
 export const LOBBY_ID = 'lobby';
 export const MAX_LOBBY_CAPACITY = 1000;
+export const DEFAULT_ROOM_NAME = '신나는 싱글 스레드 파티';

--- a/api-server/src/rooms/rooms.gateway.ts
+++ b/api-server/src/rooms/rooms.gateway.ts
@@ -192,6 +192,11 @@ export class RoomsGateway {
       } 방에 접속했습니다.`,
     });
 
+    this.server.in(LOBBY_ID).emit('change_user_count', {
+      roomId,
+      userCount: this.roomsService.roomInfo(roomId).userList.length,
+    });
+
     return {
       status: 'success',
       roomId,
@@ -199,14 +204,11 @@ export class RoomsGateway {
   }
 
   @SubscribeMessage('exit_room')
-  exitRoom(@ConnectedSocket() client: Socket, @MessageBody() data) {
-    const { roomId } = data;
-
-    this.logger.log('exit_room gateway roomID ' + roomId);
+  exitRoom(@ConnectedSocket() client: Socket) {
+    const { roomId } = client.data;
     const { name: userName } = client.data.user;
     const roomExists = this.roomsService.exitRoom(roomId, userName);
 
-    this.logger.log('exit_room gateway roomExists ' + roomExists);
     client.rooms.clear();
     if (roomExists) {
       this.server.in(roomId).emit('user_exit_room', { userName });

--- a/api-server/src/rooms/rooms.gateway.ts
+++ b/api-server/src/rooms/rooms.gateway.ts
@@ -194,7 +194,7 @@ export class RoomsGateway {
 
     this.server.in(LOBBY_ID).emit('change_user_count', {
       roomId,
-      userCount: this.roomsService.roomInfo(roomId).userList.length,
+      userCount: this.roomsService.roomUserCount(roomId),
     });
 
     return {
@@ -212,6 +212,10 @@ export class RoomsGateway {
     client.rooms.clear();
     if (roomExists) {
       this.server.in(roomId).emit('user_exit_room', { userName });
+      this.server.in(LOBBY_ID).emit('change_user_count', {
+        roomId,
+        userCount: this.roomsService.roomUserCount(roomId),
+      });
     } else {
       this.server.in(LOBBY_ID).emit('delete_room', { roomId });
     }

--- a/api-server/src/rooms/rooms.service.ts
+++ b/api-server/src/rooms/rooms.service.ts
@@ -126,14 +126,8 @@ export class RoomsService {
       (user) => user.userName !== userName,
     );
 
-    this.logger.log(
-      `[exitRoom Service] roomId: ${roomId}, this.roomList[roomId].userList.length: ${this.roomList[roomId].userList.length}`,
-    );
-
     if (roomId !== LOBBY_ID && this.roomList[roomId].userList.length === 0) {
       delete this.roomList[roomId];
-
-      this.logger.log('여기 오니?');
 
       return false;
     }

--- a/api-server/src/rooms/rooms.service.ts
+++ b/api-server/src/rooms/rooms.service.ts
@@ -4,7 +4,11 @@ import { Socket } from 'socket.io';
 import { CreateRoomInfo, Room, RoomInfo, User } from './entities/room.entity';
 import { RoomsInputDto } from './dtos/rooms.input.dto';
 import RoomsInviteDto from './dtos/rooms.invite.dto';
-import { LOBBY_ID, MAX_LOBBY_CAPACITY } from './rooms.constants';
+import {
+  DEFAULT_ROOM_NAME,
+  LOBBY_ID,
+  MAX_LOBBY_CAPACITY,
+} from './rooms.constants';
 import { WsException } from '@nestjs/websockets';
 import { RoomsUserDto } from './dtos/rooms.user.dto';
 
@@ -60,8 +64,9 @@ export class RoomsService {
     };
   }
 
-  createRoom(roomName: string, capacity: number): string {
+  createRoom(name: string, capacity: number): string {
     const roomId = uuid();
+    const roomName = name ? name : DEFAULT_ROOM_NAME;
 
     this.roomList[roomId] = {
       roomId,

--- a/api-server/src/rooms/rooms.service.ts
+++ b/api-server/src/rooms/rooms.service.ts
@@ -272,4 +272,8 @@ export class RoomsService {
       userName,
     };
   }
+
+  roomUserCount(roomId: string) {
+    return this.roomList[roomId].userList.length;
+  }
 }


### PR DESCRIPTION
방을 입퇴장할 때 로비의 있는 유저들의 방 유저카운트 정보가 갱신되도록 했다.
방 제목을 설정하지 않고 생성했을 때 기본 방 제목을 설정해줬다.