### PR TITLE
[BE] Refactor: 소켓 매퍼 수정

### DIFF
--- a/api-server/src/rooms/rooms.service.ts
+++ b/api-server/src/rooms/rooms.service.ts
@@ -28,7 +28,7 @@ export class RoomsService {
     },
   };
 
-  private userNameSocketMapper = new Map();
+  private userNameSocketIdMapper = new Map();
 
   constructor() {}
 
@@ -184,20 +184,20 @@ export class RoomsService {
     return this.roomList[roomId].userList;
   }
 
-  registerUserSocket(client: Socket, userName: string) {
-    this.userNameSocketMapper.set(userName, client);
+  registerSocketId(userName: string, socketId: string) {
+    this.userNameSocketIdMapper.set(userName, socketId);
   }
 
-  getUserSocket(userName: string) {
-    return this.userNameSocketMapper.get(userName);
+  getSocketId(userName: string) {
+    return this.userNameSocketIdMapper.get(userName);
   }
 
-  deleteUserSocket(userName: string) {
-    this.userNameSocketMapper.delete(userName);
+  deleteSocketId(userName: string) {
+    this.userNameSocketIdMapper.delete(userName);
   }
 
-  isConnctedUser(userName: string) {
-    return this.userNameSocketMapper.has(userName);
+  isConnectedUser(userName: string) {
+    return this.userNameSocketIdMapper.has(userName);
   }
 
   changeRoomState(roomId: string, state: 'waiting' | 'playing') {


### PR DESCRIPTION
userName에 소켓 객체 자체를 매핑하지 않고 소켓 객체의 id를 매핑하도록 했다.
서비스단에서 소켓 객체를 보관하고 찾는 게 적절하지 않다고 생각했다.
게이트웨이에서 웹소켓 서버의 자체적인 매핑 기능을 이용해 소켓 객체를 찾아오도록 했다.