### PR TITLE
[BE] Fix: 소켓 객체를 제대로 불러오지 못하는 문제

### DIFF
--- a/api-server/src/rooms/rooms.gateway.ts
+++ b/api-server/src/rooms/rooms.gateway.ts
@@ -348,7 +348,7 @@ export class RoomsGateway {
   }
 
   private socket(id: string): Socket {
-    return this.server.sockets[id];
+    return this.server.sockets.sockets.get(id);
   }
 
   private createItem(roomId: string) {
@@ -358,11 +358,6 @@ export class RoomsGateway {
       const socket = this.socket(socketId);
       const { name: userName } = socket.data.user;
       const item = this.roomsService.assignItem(roomId, userName);
-
-      this.logger.log(`Item created: ${item}`);
-      this.logger.log(`Item assigned to ${userName}`);
-      this.logger.log(`socketId: ${socketId}`);
-      this.logger.log(`socket: ${socket}`);
 
       socket.emit('create_item', { item });
       this.logger.log(`[createItem] Item sent to ${userName}`);


### PR DESCRIPTION
server 객체의 sockets는 네임스페이스를 가리키는 것이기 때문에 그 안에서 sockets로 한 번 더 들어가면 소켓을 매핑한 객체가 나온다. io.sockets.sockets와 같이 접근해야 한다.