### PR TITLE
[BE] Fix: 소켓 매퍼 객체 생성

### DIFF
--- a/api-server/src/rooms/rooms.service.ts
+++ b/api-server/src/rooms/rooms.service.ts
@@ -15,6 +15,7 @@ import {
 } from './rooms.constants';
 import { WsException } from '@nestjs/websockets';
 import { ItemList, RoomsUserDto } from './dtos/rooms.user.dto';
+import { Socket } from 'socket.io';
 
 @Injectable()
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
@@ -167,15 +168,15 @@ export class RoomsService {
     return this.roomList[roomId].userList.every((user) => user.ready);
   }
 
-  registerSocketId(userName: string, socketId: string) {
-    this.userNameSocketIdMapper.set(userName, socketId);
+  registerSocket(userName: string, socket: Socket) {
+    this.userNameSocketIdMapper.set(userName, socket);
   }
 
-  socketId(userName: string) {
+  socket(userName: string): Socket {
     return this.userNameSocketIdMapper.get(userName);
   }
 
-  deleteSocketId(userName: string) {
+  deleteSocket(userName: string) {
     this.userNameSocketIdMapper.delete(userName);
   }
 
@@ -277,8 +278,8 @@ export class RoomsService {
     return user.ready;
   }
 
-  roomSocketIdList(roomId: string) {
-    return this.roomList[roomId].userList.map((user) => user.socketId);
+  userNameList(roomId: string) {
+    return this.roomList[roomId].userList.map((user) => user.userName);
   }
 
   useItem(roomId: string, userName: string, item: ItemList) {
@@ -350,7 +351,7 @@ export class RoomsService {
     const { state, capacity, userList } = this.roomInfo(roomId);
     const userCount = userList.length;
 
-    if (!this.socketId(targetUserName)) {
+    if (!this.socket(targetUserName)) {
       this.logger.log(`[invite] 존재하지 않는 사용자를 초대함`);
       throw new WsException('존재하지 않는 사용자입니다.');
     }


### PR DESCRIPTION
데코레이터를 이용해 socket.io 서버 객체를 생성했을 때 소켓 ID를 통해 소켓 객체를 가져오는 게 자꾸 오류가 나서 자체적인 소켓 매퍼 객체를 다시 생성해서 사용한다.