### PR TITLE
[BE] Fix: 아이템 분배 순서 변경

### DIFF
--- a/api-server/src/rooms/rooms.gateway.ts
+++ b/api-server/src/rooms/rooms.gateway.ts
@@ -372,8 +372,8 @@ export class RoomsGateway {
 
     this.roomsService.changeRoomState(roomId, ROOM_STATE.PLAYING);
     this.roomsService.setItemCreator(roomId, itemCreator);
-    this.createItem(roomId);
     this.io.in(roomId).emit('start', { problems });
+    this.createItem(roomId);
     this.io
       .in(LOBBY_ID)
       .emit('room_start', { roomId, state: ROOM_STATE.PLAYING });


### PR DESCRIPTION
start를 emit하기 전에 create_item을 보냈기 때문에 순서를 조정했다.