### PR TITLE
[BE] Feat: 제출 게이트웨이, 유저 순위, 게임 종료 카운트다운

### DIFF
--- a/api-server/src/rooms/dtos/rooms.user.dto.ts
+++ b/api-server/src/rooms/dtos/rooms.user.dto.ts
@@ -2,6 +2,7 @@ import {
   IsBoolean,
   IsNotEmpty,
   IsNotEmptyObject,
+  IsNumber,
   IsObject,
   IsString,
 } from 'class-validator';
@@ -34,6 +35,10 @@ export class RoomsUserDto {
   @IsBoolean()
   @IsNotEmpty()
   passed: boolean;
+
+  @IsNumber()
+  @IsNotEmpty()
+  ranking: number;
 
   @IsObject()
   itemList: Record<ItemList, number>;

--- a/api-server/src/rooms/entities/rooms.user.entity.ts
+++ b/api-server/src/rooms/entities/rooms.user.entity.ts
@@ -1,4 +1,10 @@
-import { IsBoolean, IsString, IsObject, IsNotEmpty } from 'class-validator';
+import {
+  IsBoolean,
+  IsString,
+  IsObject,
+  IsNotEmpty,
+  IsNumber,
+} from 'class-validator';
 import { ItemList } from '../dtos/rooms.user.dto';
 
 export class RoomsUser {
@@ -17,6 +23,10 @@ export class RoomsUser {
   @IsBoolean()
   @IsNotEmpty()
   passed: boolean;
+
+  @IsNumber()
+  @IsNotEmpty()
+  ranking: number;
 
   @IsObject()
   itemList: Record<string, ItemList>;

--- a/api-server/src/rooms/rooms.constants.ts
+++ b/api-server/src/rooms/rooms.constants.ts
@@ -6,6 +6,7 @@ export const MAX_LOBBY_CAPACITY = 1000;
 export const DEFAULT_ROOM_NAME = '신나는 싱글 스레드 파티';
 export const NUM_OF_ITEMS = 9;
 export const MAX_ITEM_CAPACITY = 2;
+export const DEFAULT_RANKING = 0;
 export const SUCCESS_STATUS = 'success';
 export const ITEM_DELAY = 5000;
 export const ROOM_STATE = {

--- a/api-server/src/rooms/rooms.module.ts
+++ b/api-server/src/rooms/rooms.module.ts
@@ -4,9 +4,10 @@ import { RoomsGateway } from './rooms.gateway';
 import { AuthModule } from 'src/auth/auth.module';
 import { UsersModule } from 'src/users/users.module';
 import { ProblemsModule } from 'src/problems/problems.module';
+import { ScoresModule } from 'src/scores/scores.module';
 
 @Module({
   providers: [RoomsGateway, RoomsService],
-  imports: [AuthModule, UsersModule, ProblemsModule],
+  imports: [AuthModule, UsersModule, ProblemsModule, ScoresModule],
 })
 export class RoomsModule {}


### PR DESCRIPTION
클라이언트에서 코드를 제출하면 채점 서버에 API 요청을 해서 결과를 받고, 통과하면 유저 정보에 통과했다고 등록한다. 처음으로 통과한 유저인 경우엔 방의 카운트다운을 시작한다.
통과했을 때 그 방에서의 등수를 기록하고, 결과 페이지로 이동할 때 유저네임과 순위를 보내준다. 게임을 시작할 때 방 정보, 유저 정보를 초기화한다.